### PR TITLE
v1.5 remove pre-alloc, benchmark smaller number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shortscale"
-version = "1.4.0"
+version = "1.5.0"
 authors = ["Jurgen Leschner <jldec@ciaosoft.com>"]
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -54,24 +54,24 @@ For benchmarks run `RUSTFLAGS="--cfg extra" cargo bench`.
 
 GitHub Actions, running on Ubuntu.
 ```txt
-test a_shortscale                        ... bench:         290 ns/iter (+/- 20)
-test b_shortscale_string_writer_no_alloc ... bench:         265 ns/iter (+/- 47)
-test c_str_push                          ... bench:         278 ns/iter (+/- 44)
-test d_vec_push                          ... bench:         264 ns/iter (+/- 30)
-test e_display_no_alloc                  ... bench:         687 ns/iter (+/- 283)
-test f_vec_concat                        ... bench:       1,622 ns/iter (+/- 72)
-test g_string_join                       ... bench:       1,751 ns/iter (+/- 57)
+test a_shortscale                        ... bench:         262 ns/iter (+/- 42)
+test b_shortscale_string_writer_no_alloc ... bench:          99 ns/iter (+/- 17)
+test c_str_push                          ... bench:         266 ns/iter (+/- 55)
+test d_vec_push                          ... bench:         301 ns/iter (+/- 48)
+test e_display_no_alloc                  ... bench:         254 ns/iter (+/- 55)
+test f_vec_concat                        ... bench:         635 ns/iter (+/- 131)
+test g_string_join                       ... bench:         632 ns/iter (+/- 80)
 ```
 
 On MacOS Catalina 2.6 GHz Intel Core i7 memory allocation appears to be a lot slower.
 ```txt
-test a_shortscale                        ... bench:         251 ns/iter (+/- 18)
-test b_shortscale_string_writer_no_alloc ... bench:         191 ns/iter (+/- 11)
-test c_str_push                          ... bench:         247 ns/iter (+/- 22)
-test d_vec_push                          ... bench:         363 ns/iter (+/- 26)
-test e_display_no_alloc                  ... bench:         498 ns/iter (+/- 21)
-test f_vec_concat                        ... bench:       4,459 ns/iter (+/- 344)
-test g_string_join                       ... bench:       5,549 ns/iter (+/- 378)
+test a_shortscale                        ... bench:         378 ns/iter (+/- 59)
+test b_shortscale_string_writer_no_alloc ... bench:          75 ns/iter (+/- 2)
+test c_str_push                          ... bench:         396 ns/iter (+/- 42)
+test d_vec_push                          ... bench:         435 ns/iter (+/- 12)
+test e_display_no_alloc                  ... bench:         217 ns/iter (+/- 30)
+test f_vec_concat                        ... bench:       2,087 ns/iter (+/- 79)
+test g_string_join                       ... bench:       2,166 ns/iter (+/- 225)
 ```
 
 ### JavaScript
@@ -81,15 +81,15 @@ shows that JavaScript is really fast as well - faster on MacOS than my first 2 n
 
 Ubuntu, Node v14
 ```
-20000 calls, 3280000 bytes, 2211 ns/call
-20000 calls, 3280000 bytes, 2180 ns/call
-20000 calls, 3280000 bytes, 2172 ns/call
+20000 calls, 1200000 bytes, 1373 ns/call
+20000 calls, 1200000 bytes, 1336 ns/call
+20000 calls, 1200000 bytes, 1480 ns/call
 ```
 MacOS
 ```txt
-20000 calls, 3280000 bytes, 1342 ns/call
-20000 calls, 3280000 bytes, 1363 ns/call
-20000 calls, 3280000 bytes, 1342 ns/call
+20000 calls, 1200000 bytes, 967 ns/call
+20000 calls, 1200000 bytes, 982 ns/call
+20000 calls, 1200000 bytes, 965 ns/call
 ```
 
 Copyright 2021, Jürgen Leschner - github.com/jldec - MIT license

--- a/benches/bench-shortscale.rs
+++ b/benches/bench-shortscale.rs
@@ -4,7 +4,7 @@ use shortscale;
 #[cfg(extra)]
 use std::fmt::Write;
 
-const NUM: u64 = 9_007_199_254_740_991;
+const NUM: u64 = 740_991;
 
 fn a_shortscale(b: &mut Bencher) {
     let mut cnt: u64 = 0;

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -37,7 +37,7 @@ use std::fmt::Write;
 /// using [NumWords](./struct.NumWords.html) Display trait.  
 /// ...
 pub fn shortscale_display(num: u64) -> String {
-    let mut s = String::with_capacity(238);
+    let mut s = String::new();
     write!(&mut s, "{}", NumWords::new(num)).unwrap();
     return s;
 }
@@ -172,7 +172,7 @@ pub fn shortscale_str_push(num: u64) -> String {
         return String::from(map(num));
     }
 
-    let mut s = String::with_capacity(238);
+    let mut s = String::new();
 
     push_scale(&mut s, num, 1_000_000_000_000_000); // quadrillions
     push_scale(&mut s, num, 1_000_000_000_000); // trillions
@@ -249,7 +249,7 @@ pub fn shortscale_vec_push(num: u64) -> String {
         return String::from(map(num));
     }
 
-    let mut v: Strvec = Vec::with_capacity(35);
+    let mut v: Strvec = Vec::new();
 
     vec_push_scale(&mut v, num, 1_000_000_000_000_000); // quadrillions
     vec_push_scale(&mut v, num, 1_000_000_000_000); // trillions
@@ -392,7 +392,7 @@ pub fn shortscale_string_join(num: u64) -> String {
         return String::from(map(num));
     }
 
-    let mut s = String::with_capacity(238);
+    let mut s = String::new();
 
     join_words(&mut s, " ", scale_words(num, 1_000_000_000_000_000));
     join_words(&mut s, " ", scale_words(num, 1_000_000_000_000));

--- a/src/shortscale.rs
+++ b/src/shortscale.rs
@@ -28,7 +28,7 @@
 ///     );
 /// ```
 pub fn shortscale(num: u64) -> String {
-    let mut s = String::with_capacity(238);
+    let mut s = String::new();
     shortscale_string_writer(&mut s, num);
     return s;
 }


### PR DESCRIPTION
Instead of allocating for worst case longest result, err on the side of smaller allocations, and benchmark with smaller number.